### PR TITLE
Enable auto-login if token exists

### DIFF
--- a/src/pages/authen/login.jsx
+++ b/src/pages/authen/login.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
 import {
   Button,
@@ -10,7 +10,7 @@ import {
   Box,
 } from "@mui/material";
 import { SnackbarProvider, useSnackbar } from 'notistack';
-import { SysLogin } from "../../service/global_function";
+import { SysLogin, SysCheckToken } from "../../service/global_function";
 import { styled } from "@mui/system";
 import backgroundImage from "../../assets/farm_background.png";
 
@@ -36,6 +36,21 @@ const LoginPage = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({ email: "", password: "" });
   const { enqueueSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    const autoLogin = async () => {
+      const token = localStorage.getItem("x-token");
+      if (token) {
+        const valid = await SysCheckToken({ redirect: false });
+        if (valid) {
+          enqueueSnackbar("เข้าสู่ระบบอัตโนมัติ...", { variant: "info" });
+          navigate("/dashboard");
+        }
+      }
+    };
+
+    autoLogin();
+  }, [navigate, enqueueSnackbar]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/service/global_function.jsx
+++ b/src/service/global_function.jsx
@@ -3,8 +3,15 @@ import axios from "axios";
 const API_BASE = import.meta.env.VITE_API;
 const apiClient = axios.create({ baseURL: API_BASE });
 
-export async function SysCheckToken() {
+export async function SysCheckToken(options = { redirect: true }) {
   const token = localStorage.getItem("x-token");
+
+  if (!token) {
+    if (options.redirect) {
+      redirectToLogin();
+    }
+    return false;
+  }
 
   try {
     const { data } = await apiClient.post("/api/users/token", { token });
@@ -12,11 +19,15 @@ export async function SysCheckToken() {
       return true;
     }
 
-    redirectToLogin();
+    if (options.redirect) {
+      redirectToLogin();
+    }
     return false;
   } catch (error) {
     console.error("Token check failed:", error);
-    redirectToLogin();
+    if (options.redirect) {
+      redirectToLogin();
+    }
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- upgrade token check helper to allow optional redirect
- automatically navigate to dashboard if a valid token is stored

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843bb8b3b688325a2f5f4936ba89915