### PR TITLE
Remove snackbar wrapper from register page

### DIFF
--- a/src/pages/authen/register.jsx
+++ b/src/pages/authen/register.jsx
@@ -9,7 +9,7 @@ import {
   Divider,
   Box,
 } from "@mui/material";
-import { SnackbarProvider, useSnackbar } from 'notistack';
+import { useSnackbar } from 'notistack';
 import { SysRegister } from "../../service/global_function";
 import { styled } from "@mui/system";
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -166,10 +166,4 @@ const RegisterPage = () => {
   );
 };
 
-export default function RegisterPageWithSnackbar() {
-  return (
-    <SnackbarProvider maxSnack={3}>
-      <RegisterPage />
-    </SnackbarProvider>
-  );
-}
+export default RegisterPage;


### PR DESCRIPTION
## Summary
- remove local `SnackbarProvider` wrapper from register page
- export `RegisterPage` directly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c0a687b88325af2b6d2fc2e6a1e3