### PR TITLE
Add logout button near theme switcher

### DIFF
--- a/src/layouts/dashboard.jsx
+++ b/src/layouts/dashboard.jsx
@@ -2,10 +2,27 @@ import * as React from 'react';
 import { Outlet } from 'react-router';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import { PageContainer } from '@toolpad/core/PageContainer';
+import { Stack, Button } from '@mui/material';
+import { ThemeSwitcher } from '@toolpad/core/DashboardLayout';
+import { SysSignout } from '../service/global_function';
+
+function ToolbarActionsWithLogout() {
+  const handleLogout = () => {
+    SysSignout();
+  };
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <ThemeSwitcher />
+      <Button variant="outlined" size="small" onClick={handleLogout}>
+        Logout
+      </Button>
+    </Stack>
+  );
+}
 
 export default function Layout() {
   return (
-    <DashboardLayout>
+    <DashboardLayout slots={{ toolbarActions: ToolbarActionsWithLogout }}>
       <PageContainer title=''>
         <Outlet />
       </PageContainer>


### PR DESCRIPTION
## Summary
- add toolbar action with Logout button next to the dark mode ThemeSwitcher

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843c303107483259991044322a0a99e