### PR TITLE
Refactor auth pages to use shared layout

### DIFF
--- a/src/components/AuthLayout.jsx
+++ b/src/components/AuthLayout.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Container, Paper, Box } from '@mui/material';
+import { styled } from '@mui/system';
+import backgroundImage from '../assets/farm_background.png';
+
+const StyledContainer = styled(Container)({
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundImage: `url(${backgroundImage})`,
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+});
+
+const defaultPaperSx = {
+  p: '40px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  borderRadius: '15px',
+};
+
+export default function AuthLayout({
+  children,
+  maxWidth = 400,
+  paperSx = {},
+  containerProps = {},
+  wrapperProps = {},
+  paperProps = {},
+}) {
+  const { sx: wrapperSx = {}, ...otherWrapper } = wrapperProps;
+  const { sx: contSx = {}, ...otherContainer } = containerProps;
+  const { sx: pSx = {}, ...otherPaper } = paperProps;
+  return (
+    <StyledContainer maxWidth={false} sx={contSx} {...otherContainer}>
+      <Box
+        sx={{ ...(maxWidth ? { maxWidth, width: '100%' } : {}), ...wrapperSx }}
+        {...otherWrapper}
+      >
+        <Paper
+          elevation={3}
+          sx={{ ...defaultPaperSx, ...paperSx, ...pSx }}
+          {...otherPaper}
+        >
+          {children}
+        </Paper>
+      </Box>
+    </StyledContainer>
+  );
+}

--- a/src/pages/PageNotFound.jsx
+++ b/src/pages/PageNotFound.jsx
@@ -1,30 +1,29 @@
-import { Box, Button, Container, Typography } from "@mui/material";
-import { styled } from "@mui/system";
+import { Box, Button, Typography } from "@mui/material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { useNavigate } from "react-router";
-import backgroundImage from "../assets/farm_background.png";
+import AuthLayout from "../components/AuthLayout";
 
 export default function PageNotFound() {
   const navigate = useNavigate();
 
   return (
-    <StyledContainer maxWidth={false}>
-      <Box
-        sx={{
-          bgcolor: "rgba(255,255,255,0.85)",
-          p: 5,
-          borderRadius: 2,
-          textAlign: "center",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <ErrorOutlineIcon sx={{ fontSize: 80, color: "error.main", mb: 1 }} />
-        <Typography variant="h2" color="error" gutterBottom sx={{ fontWeight: "bold" }}>
-          404
-        </Typography>
+    <AuthLayout
+      maxWidth={null}
+      paperSx={{
+        bgcolor: "rgba(255,255,255,0.85)",
+        p: 5,
+        borderRadius: 2,
+        textAlign: "center",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <ErrorOutlineIcon sx={{ fontSize: 80, color: "error.main", mb: 1 }} />
+      <Typography variant="h2" color="error" gutterBottom sx={{ fontWeight: "bold" }}>
+        404
+      </Typography>
         <Typography variant="h5" color="text.secondary" paragraph>
           Sorry, page not found!
         </Typography>
@@ -43,20 +42,9 @@ export default function PageNotFound() {
             }
           }}
         >
-          กลับหน้าหลัก
-        </Button>
-      </Box>
-    </StyledContainer>
+        กลับหน้าหลัก
+      </Button>
+    </AuthLayout>
   );
 }
-
-const StyledContainer = styled(Container)({
-  minHeight: "100vh",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  backgroundImage: `url(${backgroundImage})`,
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-});
 

--- a/src/pages/authen/login.jsx
+++ b/src/pages/authen/login.jsx
@@ -1,36 +1,9 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import {
-  Button,
-  TextField,
-  Container,
-  Paper,
-  Typography,
-  Divider,
-  Box,
-} from "@mui/material";
-import { SnackbarProvider, useSnackbar } from 'notistack';
+import { Button, TextField, Typography, Divider } from "@mui/material";
+import { useSnackbar } from 'notistack';
 import { SysLogin, SysCheckToken } from "../../service/global_function";
-import { styled } from "@mui/system";
-import backgroundImage from "../../assets/farm_background.png";
-
-const StyledContainer = styled(Container)({
-  minHeight: "100vh",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  backgroundImage: `url(${backgroundImage})`,
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-});
-
-const StyledPaper = styled(Paper)({
-  padding: "40px",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  borderRadius: "15px",
-});
+import AuthLayout from "../../components/AuthLayout";
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -74,10 +47,8 @@ const LoginPage = () => {
   };
 
   return (
-    <StyledContainer maxWidth={false}>
-      <Box sx={{ maxWidth: 400, width: "100%" }}>
-        <StyledPaper elevation={3}>
-          <Typography variant="h5" color="success" sx={{ mb: 2, fontWeight: "bold", }}>Smart Farm Login</Typography>
+    <AuthLayout>
+      <Typography variant="h5" color="success" sx={{ mb: 2, fontWeight: "bold", }}>Smart Farm Login</Typography>
           <Divider sx={{ width: "100%", mb: 2}} />
           <form onSubmit={handleSubmit} style={{ width: "100%" }}>
             <TextField
@@ -134,9 +105,7 @@ const LoginPage = () => {
           >
             Welcome to Smart Farm Management System
           </Typography>
-        </StyledPaper>
-      </Box>
-    </StyledContainer>
+    </AuthLayout>
   );
 };
 

--- a/src/pages/authen/register.jsx
+++ b/src/pages/authen/register.jsx
@@ -1,37 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import {
-  Button,
-  TextField,
-  Container,
-  Paper,
-  Typography,
-  Divider,
-  Box,
-} from "@mui/material";
+import { Button, TextField, Typography, Divider, Box } from "@mui/material";
 import { useSnackbar } from 'notistack';
 import { SysRegister } from "../../service/global_function";
-import { styled } from "@mui/system";
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
-import backgroundImage from "../../assets/farm_background.png";
-
-const StyledContainer = styled(Container)({
-  minHeight: "100vh",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  backgroundImage: `url(${backgroundImage})`,
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-});
-
-const StyledPaper = styled(Paper)({
-  padding: "40px",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  borderRadius: "15px",
-});
+import AuthLayout from "../../components/AuthLayout";
 
 const RegisterPage = () => {
   const navigate = useNavigate();
@@ -97,23 +70,21 @@ const RegisterPage = () => {
   ];
 
   return (
-    <StyledContainer maxWidth={false}>
-      <Box sx={{ maxWidth: 400, width: "100%" }}>
-        <StyledPaper elevation={3}>
-          <Box sx={{ display: "flex", justifyContent: "space-between", width: "100%", mb: 2 }}>
-            <Button
-              variant="text"
-              startIcon={<ArrowBackIosNewIcon />}
-              color="success"
-              onClick={() => navigate("/")}
-              sx={{ textTransform: "none" }}
-            >
-              กลับ
-            </Button>
-            <Typography variant="h5" color="success" sx={{ fontWeight: "bold" }}>
-              Smart Farm Register
-            </Typography>
-          </Box>
+    <AuthLayout>
+      <Box sx={{ display: "flex", justifyContent: "space-between", width: "100%", mb: 2 }}>
+          <Button
+            variant="text"
+            startIcon={<ArrowBackIosNewIcon />}
+            color="success"
+            onClick={() => navigate("/")}
+            sx={{ textTransform: "none" }}
+          >
+            กลับ
+          </Button>
+          <Typography variant="h5" color="success" sx={{ fontWeight: "bold" }}>
+            Smart Farm Register
+          </Typography>
+        </Box>
 
           <Divider sx={{ width: "100%", mb: 2 }} />
 
@@ -160,9 +131,7 @@ const RegisterPage = () => {
           <Typography variant="body2" color="textSecondary" align="center" sx={{ mt: 2 }}>
             Welcome to Smart Farm Management System
           </Typography>
-        </StyledPaper>
-      </Box>
-    </StyledContainer>
+    </AuthLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- create `AuthLayout` component for reusable background and card layout
- refactor Login, Register, and PageNotFound pages to use `AuthLayout`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6843c8853c6c832598cad15de463fc65