### PR TITLE
Improve farm control system page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SmartFarm-vite-app
 SmartFarm-webapp
 
-This project includes several pages such as Login, Register, Dashboard, About
-and a newly added **Help** page for quick user guidance.
+This project includes several pages such as Login, Register, Dashboard, About,
+a **Help** page for quick user guidance and the **Farm Control System** page for
+managing user devices. On the Farm Control System page you can add, edit or
+remove devices. Each device card shows basic information and includes buttons to
+update or delete the device. A dialog form is provided for creating a new
+device while editing opens a sidebar panel for quick modifications. Device
+widgets display status chips and demonstrate realtime updates via a WebSocket
+helper function.

--- a/src/components/DeviceFormDialog.jsx
+++ b/src/components/DeviceFormDialog.jsx
@@ -1,0 +1,121 @@
+import PropTypes from "prop-types";
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Drawer,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Switch,
+  FormControlLabel,
+} from "@mui/material";
+
+export default function DeviceFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  initialData = {},
+  variant = "dialog",
+}) {
+  const [formData, setFormData] = useState({
+    device_id: "",
+    name: "",
+    status: false,
+  });
+
+  useEffect(() => {
+    setFormData({
+      device_id: initialData.device_id || "",
+      name: initialData.name || "",
+      status:
+        typeof initialData.status === "boolean" ? initialData.status : false,
+    });
+  }, [initialData]);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = () => {
+    onSubmit(formData);
+  };
+
+  const formFields = (
+    <>
+      <TextField
+        margin="dense"
+        label="Device ID"
+        name="device_id"
+        value={formData.device_id}
+        onChange={handleChange}
+        fullWidth
+      />
+      <TextField
+        margin="dense"
+        label="Name"
+        name="name"
+        value={formData.name}
+        onChange={handleChange}
+        fullWidth
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            name="status"
+            checked={formData.status}
+            onChange={handleChange}
+            color="primary"
+          />
+        }
+        label="เปิดใช้งาน"
+      />
+    </>
+  );
+
+  const actions = (
+    <Box sx={{ textAlign: 'right', mt: 2 }}>
+      <Button onClick={onClose} sx={{ mr: 1 }}>ยกเลิก</Button>
+      <Button onClick={handleSubmit} variant="contained">
+        บันทึก
+      </Button>
+    </Box>
+  );
+
+  if (variant === 'drawer') {
+    return (
+      <Drawer anchor="right" open={open} onClose={onClose}>
+        <Box sx={{ width: 320, p: 2 }} role="presentation">
+          <Typography variant="h6" gutterBottom>
+            {initialData.device_id ? 'แก้ไข' : 'เพิ่ม'}อุปกรณ์
+          </Typography>
+          {formFields}
+          {actions}
+        </Box>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{initialData.device_id ? 'แก้ไข' : 'เพิ่ม'}อุปกรณ์</DialogTitle>
+      <DialogContent>{formFields}</DialogContent>
+      <DialogActions>{actions}</DialogActions>
+    </Dialog>
+  );
+}
+
+DeviceFormDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  initialData: PropTypes.object,
+  variant: PropTypes.oneOf(['dialog', 'drawer']),
+};

--- a/src/components/DeviceWidget.jsx
+++ b/src/components/DeviceWidget.jsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  CardActions,
+  IconButton,
+  Chip,
+  Stack,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { subscribeDeviceRealtime } from "../service/global_function";
+
+export default function DeviceWidget({ device, onEdit, onDelete }) {
+  const [realtime, setRealtime] = React.useState(null);
+
+  React.useEffect(() => {
+    const unsubscribe = subscribeDeviceRealtime(device.device_id, (msg) => {
+      setRealtime(msg);
+    });
+    return unsubscribe;
+  }, [device.device_id]);
+
+  return (
+    <Card sx={{ minHeight: 200 }}>
+      {device.image && (
+        <CardMedia
+          component="img"
+          height="140"
+          image={device.image}
+          alt={device.name}
+        />
+      )}
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          {device.name}
+        </Typography>
+        <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+          {"online_status" in device && (
+            <Chip
+              label={device.online_status ? "ออนไลน์" : "ออฟไลน์"}
+              color={device.online_status ? "success" : "default"}
+              size="small"
+            />
+          )}
+          {"status" in device && (
+            <Chip
+              label={device.status ? "เปิด" : "ปิด"}
+              color={device.status ? "primary" : "default"}
+              size="small"
+            />
+          )}
+        </Stack>
+      </CardContent>
+      <CardActions>
+        <IconButton aria-label="edit" onClick={() => onEdit(device)}>
+          <EditIcon />
+        </IconButton>
+        <IconButton aria-label="delete" onClick={() => onDelete(device)}>
+          <DeleteIcon />
+        </IconButton>
+        {realtime && (
+          <Typography variant="caption" sx={{ ml: 1 }} color="text.secondary">
+            {JSON.stringify(realtime)}
+          </Typography>
+        )}
+      </CardActions>
+    </Card>
+  );
+}
+
+DeviceWidget.propTypes = {
+  device: PropTypes.shape({
+    device_id: PropTypes.string,
+    name: PropTypes.string,
+    status: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    online_status: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    image: PropTypes.string,
+  }).isRequired,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import RegisterPage from "./pages/authen/register";
 import DashboardPage from "./pages/DashboardPage";
 import AboutPage from "./pages/AboutPage";
 import HelpPage from "./pages/HelpPage";
+import FarmControlSystem from "./pages/FarmControlSystem";
 import PageNotFound from "./pages/PageNotFound";
 
 const router = createBrowserRouter([
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
           {
             path: 'help',
             Component: HelpPage,
+          },
+          {
+            path: 'farm_control_system',
+            Component: FarmControlSystem,
           },
         ],
       },

--- a/src/pages/FarmControlSystem.jsx
+++ b/src/pages/FarmControlSystem.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { Button, Container, Grid, Typography } from "@mui/material";
+import { useSnackbar } from 'notistack';
+import {
+  SysGetDevices,
+  SysCreateDevice,
+  SysUpdateDevice,
+  SysDeleteDevice,
+} from "../service/global_function";
+import DeviceWidget from "../components/DeviceWidget";
+import DeviceFormDialog from "../components/DeviceFormDialog";
+
+export default function FarmControlSystem() {
+  const [devices, setDevices] = useState([]);
+  const { enqueueSnackbar } = useSnackbar();
+  const [loading, setLoading] = useState(true);
+  const [addOpen, setAddOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [currentDevice, setCurrentDevice] = useState(null);
+
+  useEffect(() => {
+    const fetchDevices = async () => {
+      setLoading(true);
+      const data = await SysGetDevices();
+      if (Array.isArray(data)) {
+        setDevices(data);
+      } else {
+        enqueueSnackbar('ไม่พบข้อมูลอุปกรณ์', { variant: 'warning' });
+        setDevices([]);
+      }
+      setLoading(false);
+    };
+    fetchDevices();
+  }, [enqueueSnackbar]);
+
+  const openAddDialog = () => {
+    setCurrentDevice(null);
+    setAddOpen(true);
+  };
+
+  const handleEdit = (device) => {
+    setCurrentDevice(device);
+    setEditOpen(true);
+  };
+
+  const handleDelete = async (device) => {
+    if (window.confirm("ต้องการลบอุปกรณ์นี้หรือไม่?")) {
+      const success = await SysDeleteDevice(device.device_id || device.id || device._id);
+      if (success) {
+        enqueueSnackbar("ลบอุปกรณ์แล้ว", { variant: "success" });
+        setDevices((prev) => prev.filter((d) => (d.device_id || d.id || d._id) !== (device.device_id || device.id || device._id)));
+      } else {
+        enqueueSnackbar("ลบอุปกรณ์ไม่สำเร็จ", { variant: "error" });
+      }
+    }
+  };
+
+  const handleSubmit = async (values) => {
+    if (currentDevice) {
+      const updated = await SysUpdateDevice(currentDevice.device_id || currentDevice.id || currentDevice._id, values);
+      if (updated) {
+        setDevices((prev) => prev.map((d) => (d.device_id || d.id || d._id) === (currentDevice.device_id || currentDevice.id || currentDevice._id) ? updated : d));
+        enqueueSnackbar("แก้ไขอุปกรณ์แล้ว", { variant: "success" });
+      } else {
+        enqueueSnackbar("แก้ไขอุปกรณ์ไม่สำเร็จ", { variant: "error" });
+      }
+    } else {
+      const created = await SysCreateDevice(values);
+      if (created) {
+        setDevices((prev) => [...prev, created]);
+        enqueueSnackbar("เพิ่มอุปกรณ์แล้ว", { variant: "success" });
+      } else {
+        enqueueSnackbar("เพิ่มอุปกรณ์ไม่สำเร็จ", { variant: "error" });
+      }
+    }
+    setAddOpen(false);
+    setEditOpen(false);
+    setCurrentDevice(null);
+  };
+
+  return (
+    <Container>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        ระบบควบคุมฟาร์ม
+      </Typography>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={openAddDialog}>
+        เพิ่มอุปกรณ์
+      </Button>
+      {loading ? (
+        <Typography>กำลังโหลดข้อมูล...</Typography>
+      ) : (
+        <Grid container spacing={2}>
+          {devices.map((device) => (
+            <Grid item xs={12} sm={6} md={4} key={device.device_id || device.id || device._id}>
+              <DeviceWidget device={device} onEdit={handleEdit} onDelete={handleDelete} />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+      <DeviceFormDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onSubmit={handleSubmit}
+        initialData={{}}
+      />
+      <DeviceFormDialog
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSubmit={handleSubmit}
+        initialData={currentDevice || {}}
+        variant="drawer"
+      />
+    </Container>
+  );
+}

--- a/src/service/global_function.jsx
+++ b/src/service/global_function.jsx
@@ -78,6 +78,81 @@ export async function SysRegister(name, surname, email, password) {
   }
 }
 
+export async function SysGetDevices() {
+  try {
+    const token = localStorage.getItem("x-token");
+    const { data } = await apiClient.get("/api/devices", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (data.message === "OK") {
+      return data.data;
+    }
+    return [];
+  } catch (error) {
+    console.error("Fetching devices failed:", error);
+    return [];
+  }
+}
+
+export async function SysCreateDevice(payload) {
+  try {
+    const token = localStorage.getItem("x-token");
+    const { data } = await apiClient.post("/api/devices", payload, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data.message === "OK" ? data.data : null;
+  } catch (error) {
+    console.error("Create device failed:", error);
+    return null;
+  }
+}
+
+export async function SysUpdateDevice(id, payload) {
+  try {
+    const token = localStorage.getItem("x-token");
+    const { data } = await apiClient.put(`/api/devices/${id}`, payload, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data.message === "OK" ? data.data : null;
+  } catch (error) {
+    console.error("Update device failed:", error);
+    return null;
+  }
+}
+
+export async function SysDeleteDevice(id) {
+  try {
+    const token = localStorage.getItem("x-token");
+    const { data } = await apiClient.delete(`/api/devices/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data.message === "OK";
+  } catch (error) {
+    console.error("Delete device failed:", error);
+    return false;
+  }
+}
+
+export function subscribeDeviceRealtime(deviceId, onMessage) {
+  try {
+    const ws = new WebSocket(
+      `${import.meta.env.VITE_WEB_SOCKET}/ws/device/${deviceId}`
+    );
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        onMessage(msg);
+      } catch (err) {
+        console.error("MQTT parse error", err);
+      }
+    };
+    return () => ws.close();
+  } catch (error) {
+    console.error("subscribeDeviceRealtime failed", error);
+    return () => {};
+  }
+}
+
 function redirectToLogin() {
   window.location.pathname = "/";
 }


### PR DESCRIPTION
## Summary
- show each user device via improved `DeviceWidget` component
- handle add dialog and edit drawer on Farm Control System page
- update device form component to optionally render as right sidebar
- document device management features in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843cdd5295883259542217893ecfa51