### PR TITLE
Refactor sensor widget components

### DIFF
--- a/src/components/DeviceSensors.jsx
+++ b/src/components/DeviceSensors.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import { Stack } from '@mui/material';
+import TemperatureSensor from './sensors/TemperatureSensor';
+import HumiditySensor from './sensors/HumiditySensor';
+import LightSensor from './sensors/LightSensor';
+import SoilSensor from './sensors/SoilSensor';
+
+export default function DeviceSensors({ data = {} }) {
+  return (
+    <Stack spacing={0.5}>
+      <TemperatureSensor value={data.temperature} />
+      <HumiditySensor value={data.humidity} />
+      <LightSensor value={data.light} />
+      <SoilSensor value={data.soil} />
+    </Stack>
+  );
+}
+
+DeviceSensors.propTypes = {
+  data: PropTypes.object,
+};

--- a/src/components/DeviceWidget.jsx
+++ b/src/components/DeviceWidget.jsx
@@ -18,7 +18,6 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CellTowerIcon from "@mui/icons-material/CellTower";
-import GridOnIcon from '@mui/icons-material/GridOn';
 
 import { subscribeDeviceRealtime } from "../service/global_function";
 import { STYLES } from "../service/global_variable";
@@ -26,12 +25,12 @@ import { STYLES } from "../service/global_variable";
 export default function DeviceWidget({ device, onEdit, onDelete }) {
   const [realtime, setRealtime] = useState(null);
   const theme = useTheme();
-  // useEffect(() => {
-  //   const unsubscribe = subscribeDeviceRealtime(device.device_id, (msg) => {
-  //     setRealtime(msg);
-  //   });
-  //   return unsubscribe;
-  // }, [device.device_id]);
+  useEffect(() => {
+    const unsubscribe = subscribeDeviceRealtime(device.device_id, (msg) => {
+      setRealtime(msg);
+    });
+    return unsubscribe;
+  }, [device.device_id]);
 
   const signalIconBox = {
     position: "absolute",
@@ -105,7 +104,6 @@ export default function DeviceWidget({ device, onEdit, onDelete }) {
         <CardActions>
           <IconButton size="small" aria-label="edit" onClick={() => onEdit(device)} color="warning"><EditIcon /></IconButton>
           <IconButton size="small" aria-label="delete" onClick={() => onDelete(device)} color="error"><DeleteIcon /></IconButton>
-          {/* <IconButton size="small" aria-label="gridstack" color="success"><GridOnIcon /></IconButton> */}
           {realtime && (
             <Typography variant="caption" sx={{ ml: 1 }} color="text.secondary" noWrap>
               {JSON.stringify(realtime)}

--- a/src/components/sensors/HumiditySensor.jsx
+++ b/src/components/sensors/HumiditySensor.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import WaterDropIcon from '@mui/icons-material/WaterDrop';
+
+export default function HumiditySensor({ value }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <WaterDropIcon fontSize="small" color="primary" />
+      <Typography variant="body2">{value ?? '-'}</Typography>
+    </Box>
+  );
+}
+
+HumiditySensor.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/src/components/sensors/LightSensor.jsx
+++ b/src/components/sensors/LightSensor.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import LightModeIcon from '@mui/icons-material/LightMode';
+
+export default function LightSensor({ value }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <LightModeIcon fontSize="small" color="warning" />
+      <Typography variant="body2">{value ?? '-'}</Typography>
+    </Box>
+  );
+}
+
+LightSensor.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/src/components/sensors/SoilSensor.jsx
+++ b/src/components/sensors/SoilSensor.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import YardIcon from '@mui/icons-material/Yard';
+
+export default function SoilSensor({ value }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <YardIcon fontSize="small" color="success" />
+      <Typography variant="body2">{value ?? '-'}</Typography>
+    </Box>
+  );
+}
+
+SoilSensor.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/src/components/sensors/TemperatureSensor.jsx
+++ b/src/components/sensors/TemperatureSensor.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import DeviceThermostatIcon from '@mui/icons-material/DeviceThermostat';
+
+export default function TemperatureSensor({ value }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <DeviceThermostatIcon fontSize="small" color="error" />
+      <Typography variant="body2">{value ?? '-'}</Typography>
+    </Box>
+  );
+}
+
+TemperatureSensor.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/src/pages/farm/FarmGridStackOverview.jsx
+++ b/src/pages/farm/FarmGridStackOverview.jsx
@@ -1,10 +1,214 @@
+import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Typography,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
+import { GridStack } from 'gridstack';
+import 'gridstack/dist/gridstack.min.css';
+import DeviceSensors from '../../components/DeviceSensors';
+
+import {
+  getWidgetLayout,
+  saveWidgetLayout,
+} from '../../service/widget_service';
+import {
+  subscribeDeviceRealtime,
+  SysGetDeviceSensors,
+} from '../../service/global_function';
 
 export default function FarmGridStackOverview() {
   const { deviceId } = useParams();
+  const gridRef = useRef(null);
+  const grid = useRef(null);
+  const nextId = useRef(1);
+  const [widgets, setWidgets] = useState([]);
+  const [realtime, setRealtime] = useState(null);
+  const [sensors, setSensors] = useState([]);
+  const [anchorEl, setAnchorEl] = useState(null);
 
-  console.log("Device ID from params:", deviceId);
+  const handleOpenMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  useEffect(() => {
+    const unsub = subscribeDeviceRealtime(deviceId, (msg) => {
+      setRealtime(msg);
+    });
+    return unsub;
+  }, [deviceId]);
+
+  useEffect(() => {
+    (async () => {
+      const list = await SysGetDeviceSensors(deviceId);
+      setSensors(Array.isArray(list) ? list : []);
+    })();
+  }, [deviceId]);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getWidgetLayout(deviceId);
+      setWidgets(Array.isArray(data) ? data : []);
+      const maxId = data.reduce((m, w) => (w.id > m ? w.id : m), 0);
+      nextId.current = maxId + 1;
+    })();
+  }, [deviceId]);
+
+  useEffect(() => {
+    if (!gridRef.current) return;
+    if (grid.current) grid.current.destroy();
+    grid.current = GridStack.init(
+      { cellHeight: 100, float: true, margin: 5, disableOneColumnMode: true },
+      gridRef.current
+    );
+    widgets.forEach((w) => addWidgetToGrid(w));
+    return () => {
+      grid.current && grid.current.destroy();
+    };
+  }, [widgets]);
+
+  const addWidgetToGrid = (w) => {
+    if (!grid.current) return;
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('grid-stack-item');
+    wrapper.setAttribute('data-gs-id', w.id);
+    const contentDiv = document.createElement('div');
+    contentDiv.classList.add('grid-stack-item-content');
+    wrapper.appendChild(contentDiv);
+    grid.current.addWidget(wrapper, { x: w.x, y: w.y, w: w.w, h: w.h });
+    const Component = () => {
+      return (
+        <Paper sx={{ p: 1, position: 'relative', height: '100%' }}>
+          <IconButton
+            size="small"
+            sx={{ position: 'absolute', top: 4, right: 4 }}
+            onClick={() => handleRemoveWidget(w.id)}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            sx={{ position: 'absolute', top: 4, right: 30 }}
+            onClick={() => handleEditWidget(w.id)}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <Typography variant="subtitle2">{w.title}</Typography>
+          {w.type === 'sensor' && realtime && w.sensorKey && (
+            <Typography variant="caption">
+              {`${w.title}: ${realtime[w.sensorKey] ?? ''}`}
+            </Typography>
+          )}
+          {w.type === 'sensorGroup' && realtime && (
+            <DeviceSensors data={realtime} />
+          )}
+        </Paper>
+      );
+    };
+    // React 18 root render
+    import('react-dom/client').then((m) => {
+      const root = m.createRoot(contentDiv);
+      root.render(<Component />);
+    });
+  };
+
+  const handleAddSensor = async (sensor) => {
+    const payload = {
+      id: nextId.current,
+      x: 0,
+      y: 0,
+      w: 4,
+      h: 2,
+      type: 'sensor',
+      title: sensor?.name || sensor?.title || 'Sensor Widget',
+      sensorKey: sensor?.name || sensor?.port || sensor?.id,
+    };
+    setWidgets((prev) => {
+      const newWidgets = [...prev, payload];
+      saveWidgetLayout(deviceId, newWidgets);
+      return newWidgets;
+    });
+    nextId.current += 1;
+    handleCloseMenu();
+  };
+
+  const handleAddSensorGroup = () => {
+    const payload = {
+      id: nextId.current,
+      x: 0,
+      y: 0,
+      w: 4,
+      h: 3,
+      type: 'sensorGroup',
+      title: 'Sensors',
+    };
+    setWidgets((prev) => {
+      const newWidgets = [...prev, payload];
+      saveWidgetLayout(deviceId, newWidgets);
+      return newWidgets;
+    });
+    nextId.current += 1;
+    handleCloseMenu();
+  };
 
 
-  return <div>คุณกำลังดูอุปกรณ์: {deviceId}</div>;
+  const handleRemoveWidget = async (id) => {
+    setWidgets((prev) => {
+      const newWidgets = prev.filter((w) => w.id !== id);
+      saveWidgetLayout(deviceId, newWidgets);
+      return newWidgets;
+    });
+  };
+
+  const handleEditWidget = async (id) => {
+    const title = window.prompt('Widget title');
+    if (title !== null) {
+      setWidgets((prev) => {
+        const newWidgets = prev.map((w) => (w.id === id ? { ...w, title } : w));
+        saveWidgetLayout(deviceId, newWidgets);
+        return newWidgets;
+      });
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        อุปกรณ์: {deviceId}
+      </Typography>
+      <Box sx={{ mb: 1 }}>
+        <Button onClick={handleOpenMenu} variant="contained" size="small">
+          เพิ่ม Widget
+        </Button>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleCloseMenu}>
+          <MenuItem onClick={handleAddSensorGroup}>เซนเซอร์ทั้งหมด</MenuItem>
+          {sensors.map((s) => (
+            <MenuItem
+              key={s.id || s.port || s.name}
+              onClick={() => {
+                handleAddSensor(s);
+                handleCloseMenu();
+              }}
+            >
+              {s.name || s.title || s.id}
+            </MenuItem>
+          ))}
+        </Menu>
+      </Box>
+      <Box sx={{ width: '100%', height: '80vh' }}>
+        <div className="grid-stack" ref={gridRef}></div>
+      </Box>
+    </Box>
+  );
 }

--- a/src/service/global_function.jsx
+++ b/src/service/global_function.jsx
@@ -133,6 +133,30 @@ export async function SysDeleteDevice(id) {
   }
 }
 
+export async function SysGetDeviceSensors(deviceId) {
+  try {
+    const token = localStorage.getItem('x-token');
+    const { data } = await apiClient.get(`/device/${deviceId}`, {
+      headers: { Authorization: `${token}` },
+    });
+    if (Array.isArray(data.sensors)) {
+      return data.sensors;
+    }
+    if (data.data) {
+      if (Array.isArray(data.data.sensors)) {
+        return data.data.sensors;
+      }
+      if (Array.isArray(data.data)) {
+        return data.data;
+      }
+    }
+    return [];
+  } catch (error) {
+    console.error('SysGetDeviceSensors failed:', error);
+    return [];
+  }
+}
+
 export function subscribeDeviceRealtime(deviceId, onMessage) {
   try {
     const ws = new WebSocket(

--- a/src/service/widget_service.js
+++ b/src/service/widget_service.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API;
+const apiClient = axios.create({ baseURL: API_BASE });
+
+export async function getWidgetLayout(deviceId) {
+  try {
+    const token = localStorage.getItem('x-token');
+    const { data } = await apiClient.get(`/api/sensorWidget/${deviceId}`, {
+      headers: { Authorization: `${token}` },
+    });
+    if (Array.isArray(data) && data.length > 0) {
+      const layout = JSON.parse(data[0].widget_json || '[]');
+      return layout;
+    }
+    return [];
+  } catch (error) {
+    console.error('getWidgetLayout failed:', error);
+    return [];
+  }
+}
+
+export async function saveWidgetLayout(deviceId, widgets) {
+  const token = localStorage.getItem('x-token');
+  try {
+    await apiClient.post(`/api/sensorWidget/update/${deviceId}`, widgets, {
+      headers: { Authorization: `${token}` },
+    });
+    return true;
+  } catch {
+    try {
+      await apiClient.post(
+        '/api/sensorWidget',
+        { device_id: deviceId, widget_json: JSON.stringify(widgets) },
+        { headers: { Authorization: `${token}` } },
+      );
+      return true;
+    } catch (err) {
+      console.error('saveWidgetLayout failed:', err);
+      return false;
+    }
+  }
+}
+
+export async function deleteWidgetLayout(deviceId) {
+  try {
+    const token = localStorage.getItem('x-token');
+    await apiClient.delete(`/api/sensorWidget/${deviceId}`, {
+      headers: { Authorization: `${token}` },
+    });
+    return true;
+  } catch (error) {
+    console.error('deleteWidgetLayout failed:', error);
+    return false;
+  }
+}
+


### PR DESCRIPTION
## Summary
- break out sensor views into TemperatureSensor, HumiditySensor, LightSensor and SoilSensor components
- update `DeviceSensors` to use the new components so styles can be customized separately

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860e2e26fdc8325b4d49cdaeb04e833